### PR TITLE
Removes warnings thrown within PHP 8.1

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -72,9 +72,9 @@ class syntax_plugin_keyboard extends DokuWiki_Syntax_Plugin {
                 }
                 return array($state, $keys, $this->lastClass);
             case DOKU_LEXER_EXIT:
-                return array($state, '');
+                return array($state, '', '');
         }
-        return array();
+        return array($state, '', '');
     }
 
     /**


### PR DESCRIPTION
This change prevents the plugin `handle()`-method from returning an invalid array. (I.e. returning an array that can not be split into its constituents via the call of `list($state, $match, $class) = $data;`)

/resolves #24 